### PR TITLE
fix: templates can be installed from NPM again

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "chalk": "^5.3.0",
         "ejs": "^3.1.10",
+        "fs-extra": "^11.2.0",
         "ora": "^8.0.1"
       },
       "bin": {
@@ -18,8 +19,7 @@
       },
       "devDependencies": {
         "@types/node": "^20.0.0",
-        "esbuild": "^0.24.0",
-        "fs-extra": "^11.2.0"
+        "esbuild": "^0.24.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -614,7 +614,6 @@
       "version": "11.2.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.2.0.tgz",
       "integrity": "sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -641,7 +640,6 @@
       "version": "4.2.11",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
       "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
-      "dev": true,
       "license": "ISC"
     },
     "node_modules/is-interactive": {
@@ -760,7 +758,6 @@
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.1.0.tgz",
       "integrity": "sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -933,7 +930,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "chalk": "^5.3.0",
     "ejs": "^3.1.10",
+    "fs-extra": "^11.2.0",
     "ora": "^8.0.1"
   },
   "bin": {
@@ -41,7 +42,6 @@
   "license": "MIT",
   "devDependencies": {
     "esbuild": "^0.24.0",
-    "fs-extra": "^11.2.0",
     "@types/node": "^20.0.0"
   }
 }


### PR DESCRIPTION
This resolves https://github.com/ItsRiprod/deskthing-template/issues/2 where fs-extra dep was needed in the bundled package but was not present, resulting in an error.

Verified by:
 1. Bundling after dev setup `npm run build`
 2. Removing node_modules `rm -rf node_modules`
 3. Running the bundled file `node ./scripts/dist/setup.cjs`

Before this fix, would result in the error looking for `fs-extra`
After this fix, runs the script as expected
