### PR TITLE
fix: support subdirectories in package.js

### DIFF
--- a/template/full/scripts/package.js
+++ b/template/full/scripts/package.js
@@ -1,29 +1,39 @@
-import { createWriteStream } from 'fs';
-import { join, resolve } from 'path';
-import archiver from 'archiver';
-import { readdir } from 'fs/promises';
+import { createWriteStream } from "fs";
+import { join, resolve } from "path";
+import archiver from "archiver";
+import { readdir, stat } from "fs/promises";
+
+async function addFilesToArchive(archive, folderPath, baseFolder = "") {
+  const files = await readdir(folderPath);
+
+  for (const file of files) {
+    const filePath = join(folderPath, file);
+    const stats = await stat(filePath);
+
+    if (stats.isDirectory()) {
+      await addFilesToArchive(archive, filePath, join(baseFolder, file));
+    } else {
+      archive.file(filePath, { name: join(baseFolder, file) });
+    }
+  }
+}
 
 async function createPackage() {
-    const packageName = process.env.npm_package_name;
-    const version = process.env.npm_package_version;
-    const distPath = resolve('dist');
-    const outputFile = join(distPath, `${packageName}-v${version}.zip`);
-    
-    const output = createWriteStream(outputFile);
-    const archive = archiver('zip', {
-        zlib: { level: 9 }
-    });
+  const packageName = process.env.npm_package_name;
+  const version = process.env.npm_package_version;
+  const distPath = resolve("dist");
+  const outputFile = join(distPath, `${packageName}-v${version}.zip`);
 
-    archive.pipe(output);
-    
-    const files = await readdir(distPath);
-    
-    for (const file of files) {
-        if (file === `${packageName}-v${version}.zip`) continue;
-        archive.file(join(distPath, file), { name: file });
-    }
+  const output = createWriteStream(outputFile);
+  const archive = archiver("zip", {
+    zlib: { level: 9 },
+  });
 
-    await archive.finalize();
+  archive.pipe(output);
+
+  await addFilesToArchive(archive, distPath);
+
+  await archive.finalize();
 }
 
 createPackage().catch(console.error);

--- a/template/min/scripts/package.js
+++ b/template/min/scripts/package.js
@@ -1,29 +1,39 @@
-import { createWriteStream } from 'fs';
-import { join, resolve } from 'path';
-import archiver from 'archiver';
-import { readdir } from 'fs/promises';
+import { createWriteStream } from "fs";
+import { join, resolve } from "path";
+import archiver from "archiver";
+import { readdir, stat } from "fs/promises";
+
+async function addFilesToArchive(archive, folderPath, baseFolder = "") {
+  const files = await readdir(folderPath);
+
+  for (const file of files) {
+    const filePath = join(folderPath, file);
+    const stats = await stat(filePath);
+
+    if (stats.isDirectory()) {
+      await addFilesToArchive(archive, filePath, join(baseFolder, file));
+    } else {
+      archive.file(filePath, { name: join(baseFolder, file) });
+    }
+  }
+}
 
 async function createPackage() {
-    const packageName = process.env.npm_package_name;
-    const version = process.env.npm_package_version;
-    const distPath = resolve('dist');
-    const outputFile = join(distPath, `${packageName}-v${version}.zip`);
-    
-    const output = createWriteStream(outputFile);
-    const archive = archiver('zip', {
-        zlib: { level: 9 }
-    });
+  const packageName = process.env.npm_package_name;
+  const version = process.env.npm_package_version;
+  const distPath = resolve("dist");
+  const outputFile = join(distPath, `${packageName}-v${version}.zip`);
 
-    archive.pipe(output);
-    
-    const files = await readdir(distPath);
-    
-    for (const file of files) {
-        if (file === `${packageName}-v${version}.zip`) continue;
-        archive.file(join(distPath, file), { name: file });
-    }
+  const output = createWriteStream(outputFile);
+  const archive = archiver("zip", {
+    zlib: { level: 9 },
+  });
 
-    await archive.finalize();
+  archive.pipe(output);
+
+  await addFilesToArchive(archive, distPath);
+
+  await archive.finalize();
 }
 
 createPackage().catch(console.error);


### PR DESCRIPTION
Specifically this resolves the issue where icons where not included in the zip files generated by `build` script, because they are under `dist/icons/*`